### PR TITLE
modify: OnEnable OnDisable methods to be protected

### DIFF
--- a/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
+++ b/Assets/NaughtyAttributes/Scripts/Editor/NaughtyInspector.cs
@@ -15,7 +15,7 @@ namespace NaughtyAttributes.Editor
 		private IEnumerable<PropertyInfo> _nativeProperties;
 		private IEnumerable<MethodInfo> _methods;
 
-		private void OnEnable()
+		protected void OnEnable()
 		{
 			_nonSerializedFields = ReflectionUtility.GetAllFields(
 				target, f => f.GetCustomAttributes(typeof(ShowNonSerializedFieldAttribute), true).Length > 0);
@@ -27,7 +27,7 @@ namespace NaughtyAttributes.Editor
 				target, m => m.GetCustomAttributes(typeof(ButtonAttribute), true).Length > 0);
 		}
 
-		private void OnDisable()
+		protected void OnDisable()
 		{
 			ReorderableListPropertyDrawer.Instance.ClearCache();
 		}


### PR DESCRIPTION
In this way, we can inherit NaughtyInspector and still be able to receive the editor callbacks for OnEnable and OnDisable methods.

Currently, if we inherit NaughtyInspector in a class with OnEnable and OnDisable methods, we prevent Unity from calling the base class OnEnable/Disable methods, so it throws erros on the console panel because the inspector's variables have not been initialized.

The only solution is to avoid declaring OnEnable/Disable methods, which are very useful.

If the methods become protected, we will be able to call base.OnEnable() and base.OnDisable() at the start of our own methods to make it work.